### PR TITLE
Return functions and move functions to hbobsolete

### DIFF
--- a/contrib/gtwvg/paint.prg
+++ b/contrib/gtwvg/paint.prg
@@ -511,16 +511,6 @@ FUNCTION wvt_GetSaveFileName( hWnd, cDefName, cTitle, acFilter, nFlags, cInitDir
 #include "hbgtinfo.ch"
 #include "hbgtwvg.ch"
 
-#ifdef HB_LEGACY_LEVEL4
-
-FUNCTION wvt_SetTitle( cTitle )
-   RETURN hb_gtInfo( HB_GTI_WINTITLE, cTitle )
-
-FUNCTION wvt_GetTitle()
-   RETURN hb_gtInfo( HB_GTI_WINTITLE )
-
-#endif
-
 PROCEDURE wvt_SetIcon( ncIconRes, cIconName )
 
    DO CASE
@@ -538,22 +528,6 @@ FUNCTION wvt_SetFont( cFontName, nSize, nWidth, nWeight, nQuality )
       hb_defaultValue( nWidth, hb_gtInfo( HB_GTI_FONTWIDTH ) ), ;
       hb_defaultValue( nWeight, hb_gtInfo( HB_GTI_FONTWEIGHT ) ), ;
       hb_defaultValue( nQuality, hb_gtInfo( HB_GTI_FONTQUALITY ) ) } )
-
-#ifdef HB_LEGACY_LEVEL4
-
-FUNCTION wvt_SetCodepage( nCodePage )
-   RETURN hb_gtInfo( HB_GTI_CODEPAGE, nCodePage )
-
-FUNCTION wvt_GetPalette()
-   RETURN hb_gtInfo( HB_GTI_PALETTE )
-
-FUNCTION wvt_SetPalette( aRGB )
-   RETURN hb_gtInfo( HB_GTI_PALETTE, aRGB )
-
-FUNCTION wvt_GetRGBColor( nIndex )
-   RETURN hb_gtInfo( HB_GTI_PALETTE, nIndex )
-
-#endif
 
 #define BLACK               WIN_RGB( 0x00, 0x00, 0x00 )
 #define BLUE                WIN_RGB( 0x00, 0x00, 0x85 )
@@ -615,13 +589,6 @@ FUNCTION wvt_GetScreenHeight()
 
 #endif
 
-#ifdef HB_LEGACY_LEVEL5
-
-FUNCTION wvt_GetWindowHandle()
-   RETURN hb_gtInfo( HB_GTI_WINHANDLE )
-
-#endif
-
 FUNCTION wvt_CenterWindow( lCenter, lRePaint )
    RETURN hb_gtInfo( HB_GTI_SPEC, HB_GTS_CENTERWINDOW, { hb_defaultValue( lCenter, .T. ), hb_defaultValue( lRePaint, .F. ) } )
 
@@ -639,16 +606,6 @@ PROCEDURE wvt_Keyboard( nKey )
    hb_gtInfo( HB_GTI_SPEC, HB_GTS_KEYBOARD, nKey )
 
    RETURN
-
-#ifdef HB_LEGACY_LEVEL4
-
-FUNCTION wvt_GetClipboard()
-   RETURN hb_gtInfo( HB_GTI_CLIPBOARDDATA )
-
-FUNCTION wvt_SetClipboard( cText )
-   RETURN hb_gtInfo( HB_GTI_CLIPBOARDDATA, cText )
-
-#endif
 
 PROCEDURE wvt_PasteFromClipboard()
 
@@ -914,16 +871,3 @@ FUNCTION wvg_PrepareBitmapFromResource( xNameOrID, nExpWidth, nExpHeight, lMap3D
       nExpWidth, nExpHeight, ;
       iif( hb_defaultValue( lMap3Dcolors, .F. ), WIN_LR_LOADMAP3DCOLORS, WIN_LR_DEFAULTCOLOR ) )
 
-#ifdef HB_LEGACY_LEVEL5
-
-FUNCTION wvg_PrepareBitmapFromResourceId( nID, nExpWidth, nExpHeight, lMap3Dcolors )
-   RETURN wapi_LoadImage( wapi_GetModuleHandle(), nID, WIN_IMAGE_BITMAP, ;
-      nExpWidth, nExpHeight, ;
-      iif( hb_defaultValue( lMap3Dcolors, .F. ), WIN_LR_LOADMAP3DCOLORS, WIN_LR_DEFAULTCOLOR ) )
-
-FUNCTION wvg_PrepareBitmapFromResourceName( cName, nExpWidth, nExpHeight, lMap3Dcolors )
-   RETURN wapi_LoadImage( wapi_GetModuleHandle(), cName, WIN_IMAGE_BITMAP, ;
-      nExpWidth, nExpHeight, ;
-      iif( hb_defaultValue( lMap3Dcolors, .F. ), WIN_LR_LOADMAP3DCOLORS, WIN_LR_DEFAULTCOLOR ) )
-
-#endif

--- a/contrib/gtwvg/paint.prg
+++ b/contrib/gtwvg/paint.prg
@@ -557,6 +557,9 @@ FUNCTION wvt_GetRGBColorByString( cColor, nForeBack )
             s := Left( cColor, n - 1 )
          ELSE
             s := SubStr( cColor, n + 1 )
+            IF "," $ s
+               s := Left( s, At( ",", s ) - 1 )
+            ENDIF
          ENDIF
       ELSE
          s := cColor
@@ -571,23 +574,12 @@ FUNCTION wvt_GetRGBColorByString( cColor, nForeBack )
             nIndex += 8
          ENDIF
          nIndex--
+      ELSEIF Val( s ) > 0 .AND. Val( s ) < 16
+         nIndex := Val( s )
       ENDIF
    ENDIF
 
    RETURN hb_gtInfo( HB_GTI_PALETTE, nIndex )
-
-#ifdef HB_LEGACY_LEVEL4
-
-FUNCTION wvt_SetAltF4Close( lSetClose )
-   RETURN hb_gtInfo( HB_GTI_CLOSABLE, lSetClose )
-
-FUNCTION wvt_GetScreenWidth()
-   RETURN hb_gtInfo( HB_GTI_DESKTOPWIDTH )
-
-FUNCTION wvt_GetScreenHeight()
-   RETURN hb_gtInfo( HB_GTI_DESKTOPHEIGHT )
-
-#endif
 
 FUNCTION wvt_CenterWindow( lCenter, lRePaint )
    RETURN hb_gtInfo( HB_GTI_SPEC, HB_GTS_CENTERWINDOW, { hb_defaultValue( lCenter, .T. ), hb_defaultValue( lRePaint, .F. ) } )
@@ -870,4 +862,3 @@ FUNCTION wvg_PrepareBitmapFromResource( xNameOrID, nExpWidth, nExpHeight, lMap3D
    RETURN wapi_LoadImage( wapi_GetModuleHandle(), xNameOrID, WIN_IMAGE_BITMAP, ;
       nExpWidth, nExpHeight, ;
       iif( hb_defaultValue( lMap3Dcolors, .F. ), WIN_LR_LOADMAP3DCOLORS, WIN_LR_DEFAULTCOLOR ) )
-

--- a/contrib/hbobsolete/hbobsolete.hbp
+++ b/contrib/hbobsolete/hbobsolete.hbp
@@ -1,0 +1,11 @@
+-hblib
+-ohbobsolete
+-hbx=hbobsolete
+hbwin.hbc
+
+ohbmisc.prg
+ohbtip.prg
+ohbcore.prg
+ohbwin.c
+ohbwin.prg
+ohbgtinfo.prg

--- a/contrib/hbobsolete/hbobsolete.hbp
+++ b/contrib/hbobsolete/hbobsolete.hbp
@@ -1,11 +1,11 @@
 -hblib
 -ohbobsolete
 -hbx=hbobsolete
-hbwin.hbc
+{allwin}hbwin.hbc
 
-ohbmisc.prg
+{allwin}ohbmisc.prg
 ohbtip.prg
 ohbcore.prg
-ohbwin.c
-ohbwin.prg
+{allwin}ohbwin.c
+{allwin}ohbwin.prg
 ohbgtinfo.prg

--- a/contrib/hbobsolete/ohbcore.prg
+++ b/contrib/hbobsolete/ohbcore.prg
@@ -1,0 +1,8 @@
+#ifndef __XHARBOUR__
+FUNCTION hb_osPathSeparator()
+   RETURN hb_ps()
+
+FUNCTION hb_OsNewLine()
+
+   RETURN hb_Eol()
+#endif

--- a/contrib/hbobsolete/ohbcore.prg
+++ b/contrib/hbobsolete/ohbcore.prg
@@ -1,3 +1,45 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file LICENSE.txt.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA (or visit https://www.gnu.org/licenses/).
+ *
+ * As a special exception, the Harbour Project gives permission for
+ * additional uses of the text contained in its release of Harbour.
+ *
+ * The exception is that, if you link the Harbour libraries with other
+ * files to produce an executable, this does not by itself cause the
+ * resulting executable to be covered by the GNU General Public License.
+ * Your use of that executable is in no way restricted on account of
+ * linking the Harbour library code into it.
+ *
+ * This exception does not however invalidate any other reasons why
+ * the executable file might be covered by the GNU General Public License.
+ *
+ * This exception applies only to the code released by the Harbour
+ * Project under the name Harbour.  If you copy code from other
+ * Harbour Project or Free Software Foundation releases into a copy of
+ * Harbour, as the General Public License permits, the exception does
+ * not apply to the code that you add in this way.  To avoid misleading
+ * anyone as to the status of such modified files, you must delete
+ * this exception notice from them.
+ *
+ * If you write modifications of your own for Harbour, it is your choice
+ * whether to permit this exception to apply to your modifications.
+ * If you do not wish that, delete this exception notice.
+ *
+ */
+
 #ifndef __XHARBOUR__
 FUNCTION hb_osPathSeparator()
    RETURN hb_ps()

--- a/contrib/hbobsolete/ohbgtinfo.prg
+++ b/contrib/hbobsolete/ohbgtinfo.prg
@@ -1,0 +1,40 @@
+#ifndef __XHARBOUR__
+#include "hbgtinfo.ch"
+
+FUNCTION wvt_SetTitle( cTitle )
+   RETURN hb_gtInfo( HB_GTI_WINTITLE, cTitle )
+
+FUNCTION wvt_GetTitle()
+   RETURN hb_gtInfo( HB_GTI_WINTITLE )
+
+FUNCTION wvt_SetCodepage( nCodePage )
+   RETURN hb_gtInfo( HB_GTI_CODEPAGE, nCodePage )
+
+FUNCTION wvt_GetPalette()
+   RETURN hb_gtInfo( HB_GTI_PALETTE )
+
+FUNCTION wvt_SetPalette( aRGB )
+   RETURN hb_gtInfo( HB_GTI_PALETTE, aRGB )
+
+FUNCTION wvt_GetRGBColor( nIndex )
+   RETURN hb_gtInfo( HB_GTI_PALETTE, nIndex )
+
+FUNCTION wvt_GetWindowHandle()
+   RETURN hb_gtInfo( HB_GTI_WINHANDLE )
+
+FUNCTION wvt_GetClipboard()
+   RETURN hb_gtInfo( HB_GTI_CLIPBOARDDATA )
+
+FUNCTION wvt_SetClipboard( cText )
+   RETURN hb_gtInfo( HB_GTI_CLIPBOARDDATA, cText )
+
+FUNCTION wvt_SetAltF4Close( lSetClose )
+   RETURN hb_gtInfo( HB_GTI_CLOSABLE, lSetClose )
+
+FUNCTION wvt_GetScreenWidth()
+   RETURN hb_gtInfo( HB_GTI_DESKTOPWIDTH )
+
+FUNCTION wvt_GetScreenHeight()
+   RETURN hb_gtInfo( HB_GTI_DESKTOPHEIGHT )
+
+#endif

--- a/contrib/hbobsolete/ohbgtinfo.prg
+++ b/contrib/hbobsolete/ohbgtinfo.prg
@@ -1,3 +1,45 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file LICENSE.txt.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA (or visit https://www.gnu.org/licenses/).
+ *
+ * As a special exception, the Harbour Project gives permission for
+ * additional uses of the text contained in its release of Harbour.
+ *
+ * The exception is that, if you link the Harbour libraries with other
+ * files to produce an executable, this does not by itself cause the
+ * resulting executable to be covered by the GNU General Public License.
+ * Your use of that executable is in no way restricted on account of
+ * linking the Harbour library code into it.
+ *
+ * This exception does not however invalidate any other reasons why
+ * the executable file might be covered by the GNU General Public License.
+ *
+ * This exception applies only to the code released by the Harbour
+ * Project under the name Harbour.  If you copy code from other
+ * Harbour Project or Free Software Foundation releases into a copy of
+ * Harbour, as the General Public License permits, the exception does
+ * not apply to the code that you add in this way.  To avoid misleading
+ * anyone as to the status of such modified files, you must delete
+ * this exception notice from them.
+ *
+ * If you write modifications of your own for Harbour, it is your choice
+ * whether to permit this exception to apply to your modifications.
+ * If you do not wish that, delete this exception notice.
+ *
+ */
+
 #ifndef __XHARBOUR__
 #include "hbgtinfo.ch"
 

--- a/contrib/hbobsolete/ohbmisc.prg
+++ b/contrib/hbobsolete/ohbmisc.prg
@@ -1,3 +1,45 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file LICENSE.txt.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA (or visit https://www.gnu.org/licenses/).
+ *
+ * As a special exception, the Harbour Project gives permission for
+ * additional uses of the text contained in its release of Harbour.
+ *
+ * The exception is that, if you link the Harbour libraries with other
+ * files to produce an executable, this does not by itself cause the
+ * resulting executable to be covered by the GNU General Public License.
+ * Your use of that executable is in no way restricted on account of
+ * linking the Harbour library code into it.
+ *
+ * This exception does not however invalidate any other reasons why
+ * the executable file might be covered by the GNU General Public License.
+ *
+ * This exception applies only to the code released by the Harbour
+ * Project under the name Harbour.  If you copy code from other
+ * Harbour Project or Free Software Foundation releases into a copy of
+ * Harbour, as the General Public License permits, the exception does
+ * not apply to the code that you add in this way.  To avoid misleading
+ * anyone as to the status of such modified files, you must delete
+ * this exception notice from them.
+ *
+ * If you write modifications of your own for Harbour, it is your choice
+ * whether to permit this exception to apply to your modifications.
+ * If you do not wish that, delete this exception notice.
+ *
+ */
+
 #ifndef __XHARBOUR__
 FUNCTION CallDll32( ... )
    RETURN CallDll( ... )

--- a/contrib/hbobsolete/ohbmisc.prg
+++ b/contrib/hbobsolete/ohbmisc.prg
@@ -1,0 +1,4 @@
+#ifndef __XHARBOUR__
+FUNCTION CallDll32( ... )
+   RETURN CallDll( ... )
+#endif

--- a/contrib/hbobsolete/ohbtip.prg
+++ b/contrib/hbobsolete/ohbtip.prg
@@ -1,0 +1,9 @@
+#ifndef __XHARBOUR__
+FUNCTION hb_MailAssemble( ... )
+   RETURN tip_MailAssemble( ... )
+
+FUNCTION hb_SendMail( ... )
+   RETURN tip_MailSend( ... )
+#endif
+
+

--- a/contrib/hbobsolete/ohbtip.prg
+++ b/contrib/hbobsolete/ohbtip.prg
@@ -1,3 +1,45 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file LICENSE.txt.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA (or visit https://www.gnu.org/licenses/).
+ *
+ * As a special exception, the Harbour Project gives permission for
+ * additional uses of the text contained in its release of Harbour.
+ *
+ * The exception is that, if you link the Harbour libraries with other
+ * files to produce an executable, this does not by itself cause the
+ * resulting executable to be covered by the GNU General Public License.
+ * Your use of that executable is in no way restricted on account of
+ * linking the Harbour library code into it.
+ *
+ * This exception does not however invalidate any other reasons why
+ * the executable file might be covered by the GNU General Public License.
+ *
+ * This exception applies only to the code released by the Harbour
+ * Project under the name Harbour.  If you copy code from other
+ * Harbour Project or Free Software Foundation releases into a copy of
+ * Harbour, as the General Public License permits, the exception does
+ * not apply to the code that you add in this way.  To avoid misleading
+ * anyone as to the status of such modified files, you must delete
+ * this exception notice from them.
+ *
+ * If you write modifications of your own for Harbour, it is your choice
+ * whether to permit this exception to apply to your modifications.
+ * If you do not wish that, delete this exception notice.
+ *
+ */
+
 #ifndef __XHARBOUR__
 FUNCTION hb_MailAssemble( ... )
    RETURN tip_MailAssemble( ... )

--- a/contrib/hbobsolete/ohbwin.c
+++ b/contrib/hbobsolete/ohbwin.c
@@ -1,9 +1,7 @@
 /*
- * Functions deprecated from core Harbour by HB_LEGACY_LEVELn
- *   but kept in xHarbour, so they are made available here as well.
- *   Do not add internal functions (names starting with '__')
+ * Misc Windows API functions ( win_n2p(), win_p2n() )
  *
- * Copyright 2013 Viktor Szakats (vsz.me/hb)
+ * Copyright 2008-2009 Viktor Szakats (vsz.me/hb)
  *
  * This program is free software; you can redistribute it and/or modify
  * it under the terms of the GNU General Public License as published by
@@ -46,23 +44,15 @@
  *
  */
 
-#ifndef HB_LEGACY_LEVEL4
+#include "hbwapi.h"
 
-#include "hbver.ch"
 
-#if 0
+HB_FUNC( WIN_N2P )  /* NOTE: Unsafe: allows to pass arbitary pointers to functions, potentially causing a crash or worse. */
+{
+   hb_retptr( HB_ISPOINTER( 1 ) ? hb_parptr( 1 ) : ( void * ) ( HB_PTRDIFF ) hb_parnint( 1 ) );
+}
 
-FUNCTION hb_PCodeVer()
-   RETURN hb_Version( HB_VERSION_PCODE_VER_STR )
-
-FUNCTION hb_BuildDate()
-   RETURN hb_Version( HB_VERSION_BUILD_DATE_STR )
-
-FUNCTION hb_regexMatch( ... )
-   RETURN iif( hb_defaultValue( hb_PValue( 5 ), .F. ), ;
-      hb_regexLike( ... ), ;
-      hb_regexHas( ... ) )
-
-#endif
-
-#endif
+HB_FUNC( WIN_P2N )  /* NOTE: Unsafe: will reveal the numeric value of a pointer */
+{
+   hb_retnint( HB_ISNUM( 1 ) ? hb_parnint( 1 ) : ( HB_PTRDIFF ) hb_parptr( 1 ) );
+}

--- a/contrib/hbobsolete/ohbwin.prg
+++ b/contrib/hbobsolete/ohbwin.prg
@@ -1,0 +1,14 @@
+#ifndef __XHARBOUR__
+#include "hbwin.ch"
+
+FUNCTION wvg_PrepareBitmapFromResourceId( nID, nExpWidth, nExpHeight, lMap3Dcolors )
+   RETURN wapi_LoadImage( wapi_GetModuleHandle(), nID, WIN_IMAGE_BITMAP, ;
+      nExpWidth, nExpHeight, ;
+      iif( hb_defaultValue( lMap3Dcolors, .F. ), WIN_LR_LOADMAP3DCOLORS, WIN_LR_DEFAULTCOLOR ) )
+
+FUNCTION wvg_PrepareBitmapFromResourceName( cName, nExpWidth, nExpHeight, lMap3Dcolors )
+   RETURN wapi_LoadImage( wapi_GetModuleHandle(), cName, WIN_IMAGE_BITMAP, ;
+      nExpWidth, nExpHeight, ;
+      iif( hb_defaultValue( lMap3Dcolors, .F. ), WIN_LR_LOADMAP3DCOLORS, WIN_LR_DEFAULTCOLOR ) )
+
+#endif

--- a/contrib/hbobsolete/ohbwin.prg
+++ b/contrib/hbobsolete/ohbwin.prg
@@ -1,3 +1,45 @@
+/*
+ * This program is free software; you can redistribute it and/or modify
+ * it under the terms of the GNU General Public License as published by
+ * the Free Software Foundation; either version 2, or (at your option)
+ * any later version.
+ *
+ * This program is distributed in the hope that it will be useful,
+ * but WITHOUT ANY WARRANTY; without even the implied warranty of
+ * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+ * GNU General Public License for more details.
+ *
+ * You should have received a copy of the GNU General Public License
+ * along with this program; see the file LICENSE.txt.  If not, write to
+ * the Free Software Foundation, Inc., 51 Franklin Street, Fifth Floor,
+ * Boston, MA 02110-1301 USA (or visit https://www.gnu.org/licenses/).
+ *
+ * As a special exception, the Harbour Project gives permission for
+ * additional uses of the text contained in its release of Harbour.
+ *
+ * The exception is that, if you link the Harbour libraries with other
+ * files to produce an executable, this does not by itself cause the
+ * resulting executable to be covered by the GNU General Public License.
+ * Your use of that executable is in no way restricted on account of
+ * linking the Harbour library code into it.
+ *
+ * This exception does not however invalidate any other reasons why
+ * the executable file might be covered by the GNU General Public License.
+ *
+ * This exception applies only to the code released by the Harbour
+ * Project under the name Harbour.  If you copy code from other
+ * Harbour Project or Free Software Foundation releases into a copy of
+ * Harbour, as the General Public License permits, the exception does
+ * not apply to the code that you add in this way.  To avoid misleading
+ * anyone as to the status of such modified files, you must delete
+ * this exception notice from them.
+ *
+ * If you write modifications of your own for Harbour, it is your choice
+ * whether to permit this exception to apply to your modifications.
+ * If you do not wish that, delete this exception notice.
+ *
+ */
+
 #ifndef __XHARBOUR__
 #include "hbwin.ch"
 

--- a/contrib/hbobsolete/readme.txt
+++ b/contrib/hbobsolete/readme.txt
@@ -1,0 +1,9 @@
+This functions are obsolete
+
+Use source code inside this library to know about change from/to
+
+Use the library only if you do not have access to source code to make the changes.
+
+If you know about to build Harbour, you can use HB_LEGACY_LEVEL4 and HB_LEGACY_LEVEL5 variables.
+
+Check on Harbour source code about changes using these variables

--- a/contrib/hbtip/mailassy.prg
+++ b/contrib/hbtip/mailassy.prg
@@ -45,11 +45,6 @@
  *
  */
 
-#if defined( HB_LEGACY_LEVEL4 )
-FUNCTION hb_MailAssemble( ... )
-   RETURN tip_MailAssemble( ... )
-#endif
-
 FUNCTION tip_MailAssemble( ;
       cFrom, ;       /* Required. Email address of the sender */
       xTo, ;         /* Required. Character string or array of email addresses to send the email to */

--- a/contrib/hbtip/mailsend.prg
+++ b/contrib/hbtip/mailsend.prg
@@ -46,11 +46,6 @@
  *
  */
 
-#if defined( HB_LEGACY_LEVEL4 )
-FUNCTION hb_SendMail( ... )
-   RETURN tip_MailSend( ... )
-#endif
-
 /*
    cServer     -> Required. IP or domain name of the mail server
    nPort       -> Optional. Port used my email server

--- a/contrib/xhb/xhbdll.prg
+++ b/contrib/xhb/xhbdll.prg
@@ -48,5 +48,5 @@
 
 /* NOTE: This compatibility function is clashing with a function
          using a similar name but different parameter list in hbmisc */
-FUNCTION CallDll( pFunc, ... )
+FUNCTION xhbCallDll( pFunc, ... )
    RETURN iif( Empty( pFunc ),, hb_DynCall( { pFunc, HB_DYN_CALLCONV_STDCALL }, ... ) )

--- a/utils/hbmk2/hbmk2.prg
+++ b/utils/hbmk2/hbmk2.prg
@@ -2754,6 +2754,13 @@ STATIC FUNCTION __hbmk( aArgs, nArgTarget, nLevel, /* @ */ lPause, /* @ */ lExit
       DO CASE
       CASE Empty( cParam )
          /* do nothing */
+
+
+      /* trying a workaround, not sure if solve problem */
+      CASE cParamL == "-skip"
+         EXIT
+
+
       CASE hb_LeftEq( cParamL, "-comp=" ) .OR. ;
            hb_LeftEq( cParamL, "-plat=" ) .OR. ;
            hb_LeftEq( cParamL, "-compiler=" ) .OR. ; /* Compatibility HB_LEGACY_LEVEL4 */


### PR DESCRIPTION
HWGUI, HMG, HMG Extended, OOHG are libraries that may works using XHarbour, Harbour 3.2 and Harbour 3.4.
I know that if functions continues on Harbour, they will continues in use.
But for libraries, they distribute with Harbour 3.2, and this can be a reason to not use Harbour 3.4.
I think on this library hbobsolete, where we can call attention about not to use, while we give a equivalent source code solution.
At same time, we remove from original code, and left on hbobsolete, while they do not cause problem.

There is a change on CallDll() to xhbCallDll() too, because use of xhb.hbc causes conflict.

And a change on hbmk2, about -skip, but need verify why try compress a ".exe" when compress is enable and -skip is used. There already exists a check for empty name, but may be name comes as ".exe".

Check about to create hbobsolete library, to use as part of contrib. It can be an alert to all, about why to make changes.
For users... some users do not know modify library code, and if user need to add an hbobsolete library, user could ask for library developers why they uses an obsolete function, and not a new function.

And if on fucture they need anything removed, they could look at hbobsolete history, a standard folder for what becomes obsolete and was removed.

