### PR TITLE
Added MYSQL_SET_CHARACTER_SET to mysql.c

### DIFF
--- a/contrib/hbmysql/mysql.c
+++ b/contrib/hbmysql/mysql.c
@@ -636,3 +636,13 @@ HB_FUNC( MYSQL_VERSION_ID )
 {
    hb_retnl( MYSQL_VERSION_ID );
 }
+
+HB_FUNC( MYSQL_SET_CHARACTER_SET ) 
+{
+   MYSQL * mysql = hb_MYSQL_par( 1 );
+
+   if( mysql )
+      hb_retni( ( int ) mysql_set_character_set( mysql, ( const char * ) hb_parc( 2 ) ) );
+   else
+      hb_errRT_BASE( EG_ARG, 2020, NULL, HB_ERR_FUNCNAME, HB_ERR_ARGS_BASEPARAMS );
+}


### PR DESCRIPTION
This function is used to set the default character set for the current connection.